### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Cloud Foundry Command Line Interface (CLI)
 
-This [_Dockerfiles_](https://docs.docker.com/engine/reference/builder/) can be used in _Continuous Delivery_ (CD) pipelines for SAP development projects. 
+This [_Dockerfile_](https://docs.docker.com/engine/reference/builder/) can be used in _Continuous Delivery_ (CD) pipelines for SAP development projects. 
 The image is optimized for use with project ["Piper"](https://github.com/SAP/jenkins-library) on [Jenkins](https://jenkins.io/).
 Docker containers simplify your CD tool setup, encapsulating tools and environments that are required to execute pipeline steps.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,19 @@
-## CloudFoundry CLI Image
+## Cloud Foundry Command Line Interface (CLI)
 
-The CX Server is a collection of [_Dockerfiles_](https://docs.docker.com/engine/reference/builder/) for images that can be used in _Continuous Delivery_ (CD) pipelines for SAP development projects.
-The images are optimized for use with project ["Piper"](https://github.com/SAP/jenkins-library) on [Jenkins](https://jenkins.io/).
+This [_Dockerfiles_](https://docs.docker.com/engine/reference/builder/) can be used in _Continuous Delivery_ (CD) pipelines for SAP development projects. 
+The image is optimized for use with project ["Piper"](https://github.com/SAP/jenkins-library) on [Jenkins](https://jenkins.io/).
 Docker containers simplify your CD tool setup, encapsulating tools and environments that are required to execute pipeline steps.
 
 If you want to learn how to use project "Piper" please have a look at [the documentation](https://github.com/SAP/jenkins-library/blob/master/README.md).
 Introductory material and a lot of SAP scenarios not covered by project "Piper" are described in our [Continuous Integration Best Practices](https://developers.sap.com/tutorials/ci-best-practices-intro.html).
 
-This repository contains Dockerfiles that are designed to run project "Piper" pipelines.
-Nevertheless, they can also be used flexibly in any custom environment and automation process.
-
 ## About this repository
 
-Dockerfile for an image with the CloudFoundry CLI and plugins for blue-green deployment and MTA.
-This image is intended to be used in Jenkins pipelines.
+Dockerfile for an image with the Cloud Foundry CLI and plugins for blue-green deployment and Multi-Target Applications (MTA).
 
 ## Download
 
-This image is published to Docker Hub and can be pulled via the command
+This image is published to [Docker Hub](https://hub.docker.com/r/ppiper/cf-cli) and can be pulled via the command
 
 ```
 docker pull ppiper/cf-cli
@@ -25,7 +21,7 @@ docker pull ppiper/cf-cli
 
 ## Build
 
-To build this image locally, open a terminal in the directory of the Dockerfile an run
+To build this image locally, open a terminal in the directory of the Dockerfile and run
 
 ```
 docker build -t ppiper/cf-cli .
@@ -38,7 +34,7 @@ Recommended usage of this image is via [`cloudFoundryDeploy`](https://sap.github
 For using the `cf` tool via this image, it can be invoked like in this command
 
 ```
-docker run ppiper/cf-cli cf
+docker run ppiper/cf-cli cf --help
 ```
 
 ## Testing
@@ -66,6 +62,6 @@ export CX_INFRA_IT_CF_PASSWORD="mypassword"
 
 Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
 This file is licensed under the Apache Software License, v. 2 except as noted
-otherwise in the [LICENSE file](https://github.com/SAP/devops-docker-images/blob/master/LICENSE).
+otherwise in the [LICENSE file](https://github.com/SAP/devops-docker-cf-cli/blob/master/LICENSE).
 
 Please note that Docker images can contain other software which may be licensed under different licenses. This License file is also included in the Docker image. For any usage of built Docker images please make sure to check the licenses of the artifacts contained in the images.


### PR DESCRIPTION
* removed typo
* adjusted text to better fit the single Dockerfile repo
* Fix link to license
* fix Cloud Foundry naming
* improve `run` example