### PR TITLE
Use Jenkinsfile runner with fixed plugins

### DIFF
--- a/runTests.sh
+++ b/runTests.sh
@@ -26,7 +26,7 @@ pushd test-project
 docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace -v /tmp \
  -e CX_INFRA_IT_CF_PASSWORD -e CX_INFRA_IT_CF_USERNAME -e BRANCH_NAME=master \
  -e CASC_JENKINS_CONFIG=/workspace/jenkins.yml -e HOST=$(hostname) \
- ppiper/jenkinsfile-runner
+ ppiper/jenkinsfile-runner:fixed-plugins
 
 popd
 


### PR DESCRIPTION
If we merge all "Use Jenkinsfile runner with fixed plugins" PRs, we can unfix the plugins on jenkins master and the tests still run. Downside: We might stay on this fixed runner forever..