### PR TITLE
added create-service-push plugin to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry-incubator/multiapps-cli-plugi
 RUN cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org && \
     cf install-plugin blue-green-deploy -f -r CF-Community && \
     cf install-plugin ${MTA_PLUGIN_URL} -f && \
+    cf install-plugin Create-Service-Push -f -r CF-Community && \
     cf plugins


### PR DESCRIPTION
This PR adds the Create-Service-Push plugin to the image. 
Needed for a step CloudFoundryServiceCreate in https://github.com/SAP/jenkins-library/pull/892

