### PR TITLE
Support a Native Jenkins Installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # add group & user
+ARG USER_HOME=/home/piper
 RUN addgroup -gid 1000 piper && \
-    useradd piper --uid 1000 --gid 1000 --shell /bin/bash --create-home && \
+    useradd piper --uid 1000 --gid 1000 --shell /bin/bash --home-dir "${USER_HOME}" --create-home && \
     curl --location --silent "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github" | tar -zx -C /usr/local/bin && \
     cf --version
 
 USER piper
-WORKDIR /home/piper
+WORKDIR ${USER_HOME}
 
 ARG MTA_PLUGIN_VERSION=2.1.0
 ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/mta_plugin_linux_amd64
@@ -27,3 +28,7 @@ RUN cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org && \
     cf install-plugin ${MTA_PLUGIN_URL} -f && \
     cf install-plugin Create-Service-Push -f -r CF-Community && \
     cf plugins
+
+# allow anybody to read/write/exec at HOME
+RUN chmod -R o+rwx "${USER_HOME}"
+ENV HOME=${USER_HOME}


### PR DESCRIPTION
According to the [https://github.com/SAP/jenkins-library/issues/781](user permission issue), the image should be adjusted so that it can run under any user id.

For testing purposes, the adjusted image can be pulled from rstengel/cf-cli:latest

Test instances:

cx-server: https://d046169piperj383.jaas-gcp.cloud.sap.corp/job/ppiper-cx-default/
native-jenkins: http://10.47.228.211:8080/job/ppiper-cx-default/