### PR TITLE
Replace deprecated set-env github actions command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             echo "Planned next release version ($NEXT_VERSION) already exists, aborting process"
             exit 1
           fi
-          echo "::set-env name=PIPER_version::$NEXT_VERSION"
+          echo "PIPER_version=$NEXT_VERSION" >> $GITHUB_ENV
       - name: Build, test and push
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin


### PR DESCRIPTION
cf https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/