### PR TITLE
update multiapps plugin to 2.5.1 to 2.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN addgroup -gid 1000 piper && \
 USER piper
 WORKDIR ${USER_HOME}
 
-ARG MTA_PLUGIN_VERSION=2.5.1
+ARG MTA_PLUGIN_VERSION=2.6.2
 ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/mta_plugin_linux_amd64
 ARG CSPUSH_PLUGIN_VERSION=1.3.2
 ARG CSPUSH_PLUGIN_URL=https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin/releases/download/${CSPUSH_PLUGIN_VERSION}/CreateServicePushPlugin.linux64


### PR DESCRIPTION
see https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/blob/master/CHANGELOG.md
```
## v2.6.2
* Operation ID is printed as progress message (by the backend) rather than in the command

## v2.6.1
* Fixed bug with retry mechanism when switching from crashed DS instance
* BaseCommand made abstract and lowered code duplication
* General code improvements and refactoring

## v2.6.0
* Added functionality for MTAR deployment from URL
* Custom header for the size of the MTA file is added in the request to the deploy-service
* Calls to find deploy-service URL are retried
```