### PR TITLE
Use up-to-date multiapps plugin name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ USER piper
 WORKDIR ${USER_HOME}
 
 ARG MTA_PLUGIN_VERSION=2.6.3
-ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/mta_plugin_linux_amd64
+ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/multiapps-plugin.linux64
 ARG CSPUSH_PLUGIN_VERSION=1.3.2
 ARG CSPUSH_PLUGIN_URL=https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin/releases/download/${CSPUSH_PLUGIN_VERSION}/CreateServicePushPlugin.linux64
 


### PR DESCRIPTION
Replace the legacy and deprecated name for MultiApps CF CLI plugin:
mta_plugin_linux_amd64
and replace it with the new one:
multiapps-plugin.linux64