### PR TITLE
updating OS to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch-curl
+FROM buildpack-deps:bullseye-curl
 
 ENV VERSION 0.1
 


### PR DESCRIPTION
The image ran on strecht (debian 9). Updating it to bullseye (debian 11)