### PR TITLE
Update MTA plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN addgroup -gid 1000 piper && \
 USER piper
 WORKDIR ${USER_HOME}
 
-ARG MTA_PLUGIN_VERSION=3.0.3
-ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/multiapps-plugin.linux64
+ARG MTA_PLUGIN_VERSION=3.1.1
+ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/multiapps-plugin.linux64
 ARG CSPUSH_PLUGIN_VERSION=1.3.2
 ARG CSPUSH_PLUGIN_URL=https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin/releases/download/${CSPUSH_PLUGIN_VERSION}/CreateServicePushPlugin.linux64
 


### PR DESCRIPTION
The change is required because there is a high chances of problems during upload of larger MTA archives to MTA Deployment Service. This is due to recent changes in MTA deployment Service backend related to the file processing so the end customer might experience problems like: ` info  cloudFoundryDeploy - Error occurred: Post "https://deploy-service.cf.eu10.hana.ondemand.com/api/v1/spaces/<space-guid>/files": retry is needed. Retrying after: 3s.`

WIth the MultiApps CF CLI plugin version v3.1.1 there is improved and more stable mechanism in regards of the upload of MTA arhive whichmitigates the risk for larger MTA archives upload and/or latency: https://github.com/cloudfoundry/multiapps-cli-plugin/releases/tag/v3.1.1

With the previous versions of MultiApps CF CLI plugin file chunks were uploaded in parallel which might be faster in some cases but there was increased possibility of problems during upload. With the version 3.1.1 the default behavior is to perform sequential file chunks upload.  The parallel file upload can be switched on again with env variable `MULTIAPPS_UPLOAD_CHUNKS_IN_PARALLEL`

Let's consider to provide  version v3.1.1. of MultiApps CF CLI plugin to all customers as quickly as possible.