### PR TITLE
Rmv blue-green plugin for native builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ARG CSPUSH_PLUGIN_VERSION=1.3.2
 ARG CSPUSH_PLUGIN_URL=https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin/releases/download/${CSPUSH_PLUGIN_VERSION}/CreateServicePushPlugin.linux64
 
 RUN cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org && \
-    cf install-plugin blue-green-deploy -f -r CF-Community && \
     cf install-plugin ${MTA_PLUGIN_URL} -f && \
     cf install-plugin ${CSPUSH_PLUGIN_URL} -f && \
     cf install-plugin -r CF-Community "html5-plugin" -f && \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Introductory material and a lot of SAP scenarios not covered by project "Piper" 
 
 ## About this repository
 
-Dockerfile for an image with the Cloud Foundry CLI and plugins for blue-green deployment and Multi-Target Applications (MTA).
+Dockerfile for an image with the Cloud Foundry CLI and plugins for Multi-Target Applications (MTA).
 
 ## Download
 


### PR DESCRIPTION
[This plugin](https://github.com/bluemixgaragelondon/cf-blue-green-deploy) has not been updated since ages and moreover, it uses the deprecated cf api v2. As we want to use cf api v3, either the plugin should be updated accordingly or we should get rid of the dependency on it.