### PR TITLE
Update version of multiapps plugin to 3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN addgroup -gid 1000 piper && \
 USER piper
 WORKDIR ${USER_HOME}
 
-ARG MTA_PLUGIN_VERSION=3.2.0
+ARG MTA_PLUGIN_VERSION=3.2.1
 ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/multiapps-plugin.linux64
 ENV MULTIAPPS_DISABLE_UPLOAD_PROGRESS_BAR=true
 ARG CSPUSH_PLUGIN_VERSION=1.3.2


### PR DESCRIPTION
Fixed random failures during MTA archive file upload or starting operation caused by wrong CSRF token handling.