### PR TITLE
Update MTA_PLUGIN_VERSION to 3.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl https://cli.btp.cloud.sap/btpcli-install.sh | bash -s -- -o "${INSTALL_
 USER piper
 WORKDIR ${USER_HOME}
 
-ARG MTA_PLUGIN_VERSION=3.6.0
+ARG MTA_PLUGIN_VERSION=3.10.0
 ARG MTA_PLUGIN_URL=https://github.com/cloudfoundry/multiapps-cli-plugin/releases/download/v${MTA_PLUGIN_VERSION}/multiapps-plugin.linux64
 ENV MULTIAPPS_DISABLE_UPLOAD_PROGRESS_BAR=true
 ARG CSPUSH_PLUGIN_VERSION=1.3.2


### PR DESCRIPTION
Update the multiapps-cli-plugin version
Changes between 3.6.0 to 3.10.0
Improve error message to display the specific unknown flag when a cf deploy flag is misspelled
Add User-Agent header to enable end-to-end tracing and insights into plugin usage and customer workflows
Remove experimental words from help command
Version of GO is increased to 1.25.1
Upgrade Cloud Foundry CLI to version 8.17.0
Update CodeQL GitHub Action to v4
Add dependency aware stop order flag (experimental)
