### PR TITLE
chore: remove gh registry push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,8 +19,5 @@ jobs:
     - name: Run CI
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
         docker build -t ppiper/cf-cli:latest .
-        docker tag ppiper/cf-cli:latest ghcr.io/sap/ppiper-cf-cli:latest
         docker push ppiper/cf-cli:latest
-        docker push ghcr.io/sap/ppiper-cf-cli:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,8 @@ jobs:
       - name: Build, test and push
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
           docker build -t ppiper/cf-cli:${{ env.PIPER_version }} .
-          docker tag ppiper/cf-cli:${{ env.PIPER_version }} ghcr.io/sap/ppiper-cf-cli:${{ env.PIPER_version }}
           docker push ppiper/cf-cli:${{ env.PIPER_version }}
-          docker push ghcr.io/sap/ppiper-cf-cli:${{ env.PIPER_version }}
       - uses: SAP/project-piper-action@master
         with:
           piper-version: latest

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This image is published to [Docker Hub](https://hub.docker.com/r/ppiper/cf-cli) 
 docker pull ppiper/cf-cli
 ```
 
+⚠️ **Important Notice:** The GitHub Container Registry (ghcr.io) for this project is no longer being updated. Please use the Docker Hub registry instead: `docker pull ppiper/cf-cli`
+
 ## Build
 
 To build this image locally, open a terminal in the directory of the Dockerfile and run


### PR DESCRIPTION
Also remove using gh registry for this image, similar to what we did with the node-browsers repo:
https://github.com/SAP/devops-docker-node-browsers/pull/59